### PR TITLE
Fix: RDS version update for Instruqt track

### DIFF
--- a/postgres.tf
+++ b/postgres.tf
@@ -12,7 +12,7 @@ resource "aws_db_instance" "boundary_demo" {
   instance_class         = "db.t3.micro"
   allocated_storage      = 5
   engine                 = "postgres"
-  engine_version         = "13.13" #"16.1"
+  engine_version         = "13.15" #"16.1"
   username               = var.db_username
   password               = var.db_password
   db_subnet_group_name   = aws_db_subnet_group.boundary_demo_db_subnet_group.name


### PR DESCRIPTION
Following our Slack conversation on fixing Instruqt track [HCP Boundary Instruqt Track](https://play.instruqt.com/manage/hashicorp-field-ops/tracks/hcpb-secure-access)

I just updated the version number as:

- [`auto_minor_version_upgrade`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#auto_minor_version_upgrade-1) defaults to `true`
- And I don't know exactly how [`allow_major_version_upgrade`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#allow_major_version_upgrade-1) works, and it seems the middle version number is neither major nor minor, so nothing we can really change here